### PR TITLE
Prevent stretching of the canvas

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-TinyTurtle.apply(window);
+TinyTurtle.apply(window, [undefined, 400, 400]);
 
 function square(){
 forward(50);

--- a/style.css
+++ b/style.css
@@ -1,5 +1,3 @@
-canvas{
-    width: 400px;
-    height: 400px;
+canvas {
     border: 1px solid;
-    }
+}

--- a/tiny-turtle.js
+++ b/tiny-turtle.js
@@ -3,8 +3,10 @@
 // Public Domain.
 // For more information, see http://github.com/toolness/tiny-turtle.
 
-function TinyTurtle(canvas) {
+function TinyTurtle(canvas, width = 300, height = 150) {
   canvas = canvas || document.querySelector('canvas');
+  canvas.width = width;
+  canvas.height = height;
   console.log(canvas)
   var self = this;
   var rotation = 90;


### PR DESCRIPTION
Using CSS to change the width and height of the canvas causes the grid
to be stretched. In order to enlarge the canvas without distorting the
grid or causing pixelation, you must set the height and width attributes
on the canvas element itself. Unfortunately, popcode throws an error if
you use the width and height attributes in HTML, so we need to set it in
Javascript.

The default parameters for width and height have been chosen to match
the default width and height of a canvas element.

Source:
http://stackoverflow.com/questions/4938346/canvas-width-and-height-in-html5